### PR TITLE
feat: cursor ink trail + ink-bleed transition polish

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,6 +89,56 @@ body {
   @apply transition-colors duration-500;
 }
 
+/* ----------------------------------------------------------------------------
+   Ink-bleed theme transition (View Transitions API).
+   The toggle button sets --vt-x / --vt-y (icon centre), --vt-r (reach to the
+   farthest corner) and data-vt on <html>; see src/lib/theme-transition.ts.
+---------------------------------------------------------------------------- */
+@property --ink-r {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0px;
+}
+
+/* Hold the outgoing theme still beneath; bleed the incoming theme over it. */
+[data-vt='ink']::view-transition-old(root) {
+  animation: none;
+  z-index: 0;
+}
+[data-vt='ink']::view-transition-new(root) {
+  z-index: 1;
+  animation: ink-bleed 0.7s ease-out forwards;
+  /* Soft, feathered radial mask = watercolour/ink edge spreading from the icon. */
+  -webkit-mask: radial-gradient(
+    circle at var(--vt-x) var(--vt-y),
+    #000 max(0px, calc(var(--ink-r) - 110px)),
+    transparent var(--ink-r)
+  );
+  mask: radial-gradient(
+    circle at var(--vt-x) var(--vt-y),
+    #000 max(0px, calc(var(--ink-r) - 110px)),
+    transparent var(--ink-r)
+  );
+}
+@keyframes ink-bleed {
+  from { --ink-r: 0px; }
+  to   { --ink-r: var(--vt-r); }
+}
+
+/* Fallback for browsers without the View Transitions API: ease every colour
+   together for the span of the switch (data-vt is removed afterwards) so the
+   whole page changes at once instead of only the background fading. */
+[data-vt='fade'] *,
+[data-vt='fade'] *::before,
+[data-vt='fade'] *::after {
+  transition:
+    background-color 0.5s ease,
+    border-color 0.5s ease,
+    color 0.5s ease,
+    fill 0.5s ease,
+    stroke 0.5s ease;
+}
+
 /* Respect users who prefer reduced motion (covers CSS transitions/animations;
    framer-motion is handled via <MotionConfig reducedMotion="user">). */
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,23 +106,29 @@ body {
   z-index: 0;
 }
 [data-vt='ink']::view-transition-new(root) {
+  /* Width of the soft edge between revealed and not-yet-revealed. */
+  --ink-feather: 110px;
   z-index: 1;
   animation: ink-bleed 0.7s ease-out forwards;
   /* Soft, feathered radial mask = watercolour/ink edge spreading from the icon. */
   -webkit-mask: radial-gradient(
     circle at var(--vt-x) var(--vt-y),
-    #000 max(0px, calc(var(--ink-r) - 110px)),
+    #000 max(0px, calc(var(--ink-r) - var(--ink-feather))),
     transparent var(--ink-r)
   );
   mask: radial-gradient(
     circle at var(--vt-x) var(--vt-y),
-    #000 max(0px, calc(var(--ink-r) - 110px)),
+    #000 max(0px, calc(var(--ink-r) - var(--ink-feather))),
     transparent var(--ink-r)
   );
 }
+/* Animate to vt-r + feather so the *solid* front (which trails the leading edge
+   by one feather width) sweeps fully past the farthest corner before the View
+   Transition snapshot is torn down — otherwise that corner is still mid-feather
+   and snaps to solid, looking "unsmooth" (most visible at the bottom-left). */
 @keyframes ink-bleed {
   from { --ink-r: 0px; }
-  to   { --ink-r: var(--vt-r); }
+  to   { --ink-r: calc(var(--vt-r) + var(--ink-feather)); }
 }
 
 /* Fallback for browsers without the View Transitions API: ease every colour

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { type Metadata } from 'next';
 import Link from 'next/link';
 import AnimatedHeading from '@/components/animated-heading';
+import GridInkTrail from '@/components/grid-ink-trail';
 import Container from '@/components/layout/container';
 import JsonLd from '@/components/seo/json-ld';
 import ViewportWidth from '@/components/ui/viewport-width';
@@ -27,9 +28,10 @@ const personSchema = {
 
 const Page = () => {
   return (
-    <main className='bp-grid flex flex-1 items-center'>
+    <main className='bp-grid relative flex flex-1 items-center overflow-hidden'>
       <JsonLd data={personSchema} />
-      <Container as='section' className='w-full py-12'>
+      <GridInkTrail />
+      <Container as='section' className='relative z-10 w-full py-12'>
         {/* Mono eyebrow */}
         <p className='font-mono text-xs uppercase tracking-[0.14em] text-primary'>
           Personal site · 個人網站

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -74,12 +74,6 @@ const Footer = (): React.JSX.Element => {
             >
               View source ↗
             </a>
-            <span className='font-mono mb-1.5 block text-xs font-semibold text-muted'>
-              Next.js · static
-            </span>
-            <span className='font-mono mb-1.5 block text-xs font-semibold text-muted'>
-              Blueprint v2.0
-            </span>
           </div>
         </div>
 
@@ -87,9 +81,6 @@ const Footer = (): React.JSX.Element => {
         <div className='flex flex-wrap items-center justify-between gap-2 border-t border-primary/20 py-3'>
           <span className='font-mono text-[10px] font-semibold text-muted'>
             © {year} SHIMEMING · 銘
-          </span>
-          <span className='font-mono text-[10px] font-semibold text-muted'>
-            <b className='text-primary'>REV 2.0</b>
           </span>
           <span className='font-mono text-[10px] font-semibold text-muted'>
             LAST UPDATED · {lastUpdated.toUpperCase()}

--- a/src/components/grid-ink-trail.tsx
+++ b/src/components/grid-ink-trail.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Brush-style ink trail that follows the cursor across the blueprint grid.
+ * - Colour is read from the `--primary` token, so it tracks light/dark.
+ * - Stroke width swells when the cursor slows and thins when it moves fast.
+ * - Stamps fade out, leaving a transient trail.
+ * Renders an absolutely-positioned canvas; the parent must be `relative`.
+ */
+
+type Stamp = { x: number; y: number; r: number; life: number };
+
+// Brush feel (matches the approved "blue brush, default size" preset).
+const W_MIN = 3;
+const W_MAX = 12;
+const BASE_ALPHA = 0.5;
+const SPACING = 1.4;     // px between stamps along the path
+const FADE = 0.02;       // life lost per frame (~0.8s lifetime)
+const MAX_STAMPS = 1200;
+const SPRITE = 64;       // pre-rendered brush sprite size (px)
+
+const GridInkTrail = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Honour reduced-motion: no trail at all.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    // --- soft brush sprite, tinted from --primary and rebuilt on theme change ---
+    const sprite = document.createElement('canvas');
+    sprite.width = sprite.height = SPRITE;
+    const sctx = sprite.getContext('2d')!;
+    const buildSprite = () => {
+      const hex = getComputedStyle(document.documentElement)
+        .getPropertyValue('--primary')
+        .trim();
+      const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+      const r = m ? parseInt(m[1], 16) : 30;
+      const g = m ? parseInt(m[2], 16) : 95;
+      const b = m ? parseInt(m[3], 16) : 204;
+      sctx.clearRect(0, 0, SPRITE, SPRITE);
+      const grad = sctx.createRadialGradient(SPRITE / 2, SPRITE / 2, 0, SPRITE / 2, SPRITE / 2, SPRITE / 2);
+      grad.addColorStop(0, `rgba(${r},${g},${b},1)`);
+      grad.addColorStop(1, `rgba(${r},${g},${b},0)`);
+      sctx.fillStyle = grad;
+      sctx.fillRect(0, 0, SPRITE, SPRITE);
+    };
+    buildSprite();
+    const themeObserver = new MutationObserver(buildSprite);
+    themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-mode'] });
+
+    // --- canvas sizing (DPR aware) ---
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = canvas.clientWidth * dpr;
+      canvas.height = canvas.clientHeight * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+
+    // --- trail state ---
+    const stamps: Stamp[] = [];
+    let smoothR: number | null = null;
+    let last: { x: number; y: number; t: number } | null = null;
+
+    const emit = (x0: number, y0: number, x1: number, y1: number, dt: number) => {
+      const dx = x1 - x0;
+      const dy = y1 - y0;
+      const dist = Math.hypot(dx, dy);
+      if (dist > 140) return; // ignore big jumps (cursor re-entry)
+      const speed = dist / Math.max(dt, 1); // px per ms
+      const k = Math.min(speed / 2, 1);
+      const target = W_MAX - k * (W_MAX - W_MIN); // slow → thick, fast → thin
+      smoothR = smoothR == null ? target : smoothR + (target - smoothR) * 0.35;
+      const steps = Math.max(1, Math.floor(dist / SPACING));
+      for (let i = 0; i < steps; i++) {
+        const f = i / steps;
+        stamps.push({ x: x0 + dx * f, y: y0 + dy * f, r: smoothR, life: 1 });
+      }
+      while (stamps.length > MAX_STAMPS) stamps.shift();
+    };
+
+    const onMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      if (x < 0 || y < 0 || x > rect.width || y > rect.height) {
+        last = null;
+        smoothR = null;
+        return;
+      }
+      const t = performance.now();
+      if (last) emit(last.x, last.y, x, y, t - last.t);
+      last = { x, y, t };
+    };
+    window.addEventListener('mousemove', onMove);
+
+    let raf = 0;
+    const loop = () => {
+      ctx.clearRect(0, 0, canvas.clientWidth, canvas.clientHeight);
+      for (let i = stamps.length - 1; i >= 0; i--) {
+        const s = stamps[i];
+        s.life -= FADE;
+        if (s.life <= 0) {
+          stamps.splice(i, 1);
+          continue;
+        }
+        const r = Math.max(s.r, 0.5);
+        ctx.globalAlpha = BASE_ALPHA * s.life;
+        ctx.drawImage(sprite, s.x - r, s.y - r, r * 2, r * 2);
+      }
+      ctx.globalAlpha = 1;
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('mousemove', onMove);
+      ro.disconnect();
+      themeObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden='true'
+      className='pointer-events-none absolute inset-0 h-full w-full'
+    />
+  );
+};
+
+export default GridInkTrail;

--- a/src/components/theme-toggle-button.tsx
+++ b/src/components/theme-toggle-button.tsx
@@ -2,6 +2,7 @@
 import { motion } from 'motion/react';
 import { useTheme } from 'next-themes';
 import { useState, useEffect } from 'react';
+import { runThemeTransition } from '@/lib/theme-transition';
 
 // ref: https://jfelix.info/blog/using-react-spring-to-animate-svg-icons-dark-mode-toggle
 
@@ -39,8 +40,12 @@ const ThemeToggleButton = ({
 
   const isDarkMode = mounted && resolvedTheme === 'dark';
 
-  const toggleDarkMode = () => {
-    setTheme(isDarkMode ? 'light' : 'dark');
+  const toggleDarkMode = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const next = isDarkMode ? 'light' : 'dark';
+    // Ink bleed spreads from the centre of the toggle icon.
+    const rect = event.currentTarget.getBoundingClientRect();
+    const origin = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    runThemeTransition(next, origin, setTheme);
   };
 
   const { r, transform, cx, cy, opacity } = isDarkMode ? properties.sun : properties.moon;

--- a/src/lib/__tests__/theme-transition.test.ts
+++ b/src/lib/__tests__/theme-transition.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runThemeTransition } from '../theme-transition';
+
+/** Build a fake <html> element that records the calls the helper makes. */
+function makeRoot() {
+  return {
+    style: { setProperty: vi.fn() },
+    setAttribute: vi.fn(),
+    removeAttribute: vi.fn(),
+    clientWidth: 100,
+    clientHeight: 50,
+  };
+}
+
+describe('runThemeTransition', () => {
+  it('crossfades instead of revealing when the View Transitions API is unavailable', () => {
+    vi.useFakeTimers();
+    try {
+      const root = makeRoot();
+      const doc = { documentElement: root } as unknown as Document; // no startViewTransition
+      const setTheme = vi.fn();
+
+      runThemeTransition('dark', { x: 10, y: 20 }, setTheme, { doc, reducedMotion: false });
+
+      // Switches the theme and enables a temporary page-wide colour crossfade...
+      expect(setTheme).toHaveBeenCalledWith('dark');
+      expect(root.setAttribute).toHaveBeenCalledWith('data-vt', 'fade');
+      expect(root.style.setProperty).not.toHaveBeenCalled(); // no reveal geometry
+
+      // ...then tears the crossfade flag down once it has finished.
+      expect(root.removeAttribute).not.toHaveBeenCalled();
+      vi.runAllTimers();
+      expect(root.removeAttribute).toHaveBeenCalledWith('data-vt');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('switches theme instantly with no crossfade when the user prefers reduced motion', () => {
+    const root = makeRoot();
+    const startViewTransition = vi.fn();
+    const doc = { documentElement: root, startViewTransition } as unknown as Document;
+    const setTheme = vi.fn();
+
+    runThemeTransition('dark', { x: 10, y: 20 }, setTheme, { doc, reducedMotion: true });
+
+    expect(setTheme).toHaveBeenCalledWith('dark');
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(root.setAttribute).not.toHaveBeenCalledWith('data-vt', expect.anything());
+  });
+
+  it('runs a view transition from the origin and applies the theme inside the callback', () => {
+    const root = makeRoot();
+    let captured: (() => void) | undefined;
+    const startViewTransition = vi.fn((cb: () => void) => {
+      captured = cb;
+      return { finished: Promise.resolve(), ready: Promise.resolve(), updateCallbackDone: Promise.resolve() };
+    });
+    const doc = { documentElement: root, startViewTransition } as unknown as Document;
+    const setTheme = vi.fn();
+
+    runThemeTransition('dark', { x: 10, y: 20 }, setTheme, { doc, reducedMotion: false });
+
+    // origin + reach to the farthest corner are exposed as CSS custom properties
+    expect(root.style.setProperty).toHaveBeenCalledWith('--vt-x', '10px');
+    expect(root.style.setProperty).toHaveBeenCalledWith('--vt-y', '20px');
+    const expectedR = Math.hypot(Math.max(10, 100 - 10), Math.max(20, 50 - 20));
+    expect(root.style.setProperty).toHaveBeenCalledWith('--vt-r', `${expectedR}px`);
+    expect(root.setAttribute).toHaveBeenCalledWith('data-vt', 'ink');
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+
+    // theme is NOT applied until the snapshot callback runs
+    expect(setTheme).not.toHaveBeenCalled();
+    captured?.();
+    expect(root.setAttribute).toHaveBeenCalledWith('data-mode', 'dark');
+    expect(setTheme).toHaveBeenCalledWith('dark');
+  });
+});

--- a/src/lib/theme-transition.ts
+++ b/src/lib/theme-transition.ts
@@ -1,0 +1,85 @@
+/**
+ * Ink-bleed theme switch built on the View Transitions API.
+ *
+ * The new theme is revealed with a soft, feathered radial mask that spreads
+ * from the toggle icon (see the `[data-vt="ink"]` rules in globals.css).
+ *
+ * Why we apply `data-mode` ourselves inside the snapshot callback: `next-themes`
+ * sets that attribute from a React effect, which runs *after* the callback
+ * returns — too late for the View Transition snapshot to capture it. Setting it
+ * directly guarantees the "after" snapshot shows the new theme; `setTheme` is
+ * still called so next-themes keeps its state and localStorage in sync.
+ */
+
+type ViewTransition = { finished: Promise<unknown> };
+
+/** Lifetime of the fallback crossfade; must outlast the CSS transition. */
+const FADE_MS = 600;
+
+type DocumentWithViewTransitions = Document & {
+  startViewTransition?: (callback: () => void) => ViewTransition;
+};
+
+export interface ThemeTransitionOptions {
+  /** Injectable for tests. Defaults to the global `document`. */
+  doc?: Document;
+  /**
+   * Injectable for tests. Defaults to the `prefers-reduced-motion` media query.
+   */
+  reducedMotion?: boolean;
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+export function runThemeTransition(
+  next: string,
+  origin: { x: number; y: number },
+  setTheme: (theme: string) => void,
+  options: ThemeTransitionOptions = {},
+): void {
+  const doc = (options.doc ?? document) as DocumentWithViewTransitions;
+  const root = doc.documentElement;
+  const reduced = options.reducedMotion ?? prefersReducedMotion();
+
+  // Reduced-motion request: switch instantly, no reveal and no crossfade.
+  if (reduced) {
+    setTheme(next);
+    return;
+  }
+
+  // No View Transitions support (e.g. older Firefox): fall back to a brief
+  // page-wide colour crossfade so surfaces, borders and text change together
+  // (see `[data-vt='fade']` in globals.css) instead of the page "tearing".
+  if (typeof doc.startViewTransition !== 'function') {
+    root.setAttribute('data-vt', 'fade');
+    setTheme(next);
+    const timer = setTimeout(() => root.removeAttribute('data-vt'), FADE_MS);
+    (timer as unknown as { unref?: () => void }).unref?.();
+    return;
+  }
+
+  const { x, y } = origin;
+  const endRadius = Math.hypot(
+    Math.max(x, root.clientWidth - x),
+    Math.max(y, root.clientHeight - y),
+  );
+  root.style.setProperty('--vt-x', `${x}px`);
+  root.style.setProperty('--vt-y', `${y}px`);
+  root.style.setProperty('--vt-r', `${endRadius}px`);
+  root.setAttribute('data-vt', 'ink');
+
+  const transition = doc.startViewTransition(() => {
+    root.setAttribute('data-mode', next);
+    setTheme(next);
+  });
+
+  transition.finished.finally(() => {
+    root.removeAttribute('data-vt');
+  });
+}


### PR DESCRIPTION
## Summary

Adds cursor interaction to the blueprint grid background and finishes off the ink-bleed theme transition. This branch builds on the unmerged ink-bleed transition work, so the PR also brings that commit in.

## Commits
- **feat: ink-bleed light/dark transition** _(prior)_ — watercolour/ink reveal on theme toggle via the View Transitions API.
- **fix: smooth ink-bleed transition's far-corner snap** — add `--ink-feather` and animate `--ink-r` past the farthest corner so the reveal no longer snaps to solid (most visible bottom-left).
- **chore: trim redundant footer meta labels** — drop the Next.js/static, Blueprint v2.0, and REV 2.0 labels.
- **feat: cursor-following ink-brush trail on the grid background** — the new `GridInkTrail` canvas overlay.

## The ink trail
- Blue **brush** stroke that follows the cursor; width swells when the cursor slows and thins when it moves fast.
- Colour is read from the `--primary` token, so it tracks **light/dark** automatically.
- Strokes **fade** (~0.8s), leaving a transient trail.
- Pre-rendered brush sprite for performance; stamps are capped and culled as they fade.
- Fully disabled under `prefers-reduced-motion`; `aria-hidden` + `pointer-events-none`.
- Sits **behind** the hero content, so readability is unaffected.

## Verification
- `pnpm lint` — clean.
- Verified live on the dev server: canvas mounts and fills `main`, paints blue (matching `--primary`), light + dark both confirmed, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)